### PR TITLE
Simplify side CZT calorimeter layer configuration

### DIFF
--- a/AMEGO_4x4TowerModel/AmegoBase.geo.setup
+++ b/AMEGO_4x4TowerModel/AmegoBase.geo.setup
@@ -56,7 +56,13 @@ CalCZT.Mother World
 Volume CZTSideDetector
 CZTSideDetector.Material Vacuum
 CZTSideDetector.Visibility 0
-CZTSideDetector.Shape BRIK 37.5 10.0 2.1
+Constant NLayers 4
+If {NLayers < 50}
+    CZTSideDetector.Shape BRIK 37.5 {2.5*NLayers} 2.1
+EndIf
+If {NLayers > 50}
+    CZTSideDetector.Shape BRIK 37.5 2.5 2.1
+EndIf
 
 CZTSideLayer.Mother CZTSideDetector
 
@@ -83,14 +89,14 @@ Done
 For I 2 -20.0 40.0
     For J 2 -20.0 40.0 
 	CZTSideDetector.Copy CZTSideDetector_%I_%J
-	CZTSideDetector_1_1.Position 0. -47.5 6.0
-	CZTSideDetector_1_2.Position -47.5 0. 6.0
-	CZTSideDetector_2_1.Position 0. 47.5 6.0
-	CZTSideDetector_2_2.Position 47.5 0. 6.0
-	CZTSideDetector_1_1.Rotation -90.0 0.0 0.0
+	CZTSideDetector_1_1.Position 0. -47.5 {2.5*NLayers-4}
+	CZTSideDetector_1_2.Position -47.5 0. {2.5*NLayers-4}
+	CZTSideDetector_2_1.Position 0. 47.5 {2.5*NLayers-4}
+	CZTSideDetector_2_2.Position 47.5 0. {2.5*NLayers-4}
+	CZTSideDetector_1_1.Rotation 90.0 0.0 0.0
 	CZTSideDetector_1_2.Rotation 90.0 0.0 90.0 
 	CZTSideDetector_2_1.Rotation 90.0 0.0 0.0
-	CZTSideDetector_2_2.Rotation -90.0 0.0 90.0  
+	CZTSideDetector_2_2.Rotation 90.0 0.0 90.0  
 	CZTSideDetector_%I_%J.Mother World
 	
 	CZTLogDetector.Copy CZTDetector_%I_%J

--- a/AMEGO_4x4TowerModel/CalorimeterCZTLogDetector.geo
+++ b/AMEGO_4x4TowerModel/CalorimeterCZTLogDetector.geo
@@ -38,17 +38,20 @@ Volume CZTSideLayer
 CZTSideLayer.Material Vacuum
 CZTSideLayer.Visibility 1
 CSTSideLayer.Color 2
-CZTSideLayer.Shape BRIK 37.5 10.0 2.1
 // Include this to run in stand-alone
 //CZTSideLayer.Mother 0
 
-//Adds the segments to build the side layer
-For I 15 -35. 5.
-    For J 4 -7.5 5.
-    	CZTSideSegment.Copy CZTSideSegment_%I_%J
-    	CZTSideSegment_%I_%J.Position $I $J 0.0
-    	CZTSideSegment_%I_%J.Mother CZTSideLayer
+If {NLayers < 50} // Workaround for bug in Geomega where setting NLayers to zero would cause an exception in the for loop. Instead, set NLayers above 50 to disable sideCZT
+    CZTSideLayer.Shape BRIK 37.5 {2.5*NLayers} 2.1
+    //Adds the segments to build the side layer
+    For I 15 -35. 5.
+        For J {NLayers} -7.5 5. // Increase NLayers to increase height
+            CZTSideSegment.Copy CZTSideSegment_%I_%J
+            CZTSideSegment_%I_%J.Position $I {$J-2.5*(NLayers-4)} 0
+            CZTSideSegment_%I_%J.Mother CZTSideLayer
+        Done
     Done
-Done
-
-
+EndIf
+If {NLayers > 50}
+    CZTSideLayer.Shape BRIK 37.5 2.5 2.1
+EndIf


### PR DESCRIPTION
In the existing geometry, the number of side CZT layers is hard coded to 4. Seven values in two files are built around that number and will create invalid geometries if any other value is used. 

This code fixes that problem by modifying the code to instead reference a single constant (NLayers) throughout the geometry.

Limitations: a maximum of 50 layers are supported due to a workaround for a bug in Geomega. However, overlaps with the topACD will occur well before that limit is reached.