### PR TITLE
Voxel tracker

### DIFF
--- a/AMEGO_Midex/TradeStudies/Tracker/BasePixelTracker/SiStripProperties.det
+++ b/AMEGO_Midex/TradeStudies/Tracker/BasePixelTracker/SiStripProperties.det
@@ -1,15 +1,15 @@
 //Define Silicon Planes and whole volume to contain planes
-MDStrip2D		SStrip
+Voxel3D		SStrip
 
 SStrip.SensitiveVolume  Wafer
 SStrip.DetectorVolume   Wafer
-SStrip.StructuralPitch 0.0 0.0 1.0
+SStrip.StructuralPitch 0.0 0.0 1.5
 //Do not indlude this part
 //SStrip.StructuralOffset 0.2 0.2 0.0
 SStrip.Offset          0.0  0.0
 
 //Total # of strips given by width of plane/strip pitch. Assume 0.250mm strip pitch
-SStrip.StripNumber 380.0 380.0
+SStrip.VoxelNumber 380 380 1
 
 
 //Base Design
@@ -23,8 +23,10 @@ SStrip.StripNumber 380.0 380.0
 //Pixel Properties
 //Set Physical properties of pixels
 SStrip.NoiseThreshold       5
-SStrip.TriggerThreshold     20
+SStrip.TriggerThreshold     25
 
-SStrip.EnergyResolution Gauss 662 662 8.5
-SStrip.EnergyResolution Gauss 122 122 4.38
+SStrip.EnergyResolution Gauss 662 662 5.6
+SStrip.EnergyResolution Gauss 122 122 5.0
+SStrip.EnergyResolution Gauss  25  25 5.0
+
 

--- a/AMEGO_Midex/TradeStudies/Tracker/BasePixelTracker/SiStripProperties.det
+++ b/AMEGO_Midex/TradeStudies/Tracker/BasePixelTracker/SiStripProperties.det
@@ -1,15 +1,15 @@
 //Define Silicon Planes and whole volume to contain planes
-Voxel3D		SStrip
+Strip2D		SStrip
 
 SStrip.SensitiveVolume  Wafer
 SStrip.DetectorVolume   Wafer
 SStrip.StructuralPitch 0.0 0.0 1.5
 //Do not indlude this part
 //SStrip.StructuralOffset 0.2 0.2 0.0
-SStrip.Offset          0.0  0.0 0.0
+SStrip.Offset          0.0  0.0
 
 //Total # of strips given by width of plane/strip pitch. Assume 0.250mm strip pitch
-SStrip.VoxelNumber 380 380 1
+SStrip.StripNumber 380 380
 
 
 //Base Design

--- a/AMEGO_Midex/TradeStudies/Tracker/BasePixelTracker/SiStripProperties.det
+++ b/AMEGO_Midex/TradeStudies/Tracker/BasePixelTracker/SiStripProperties.det
@@ -6,7 +6,7 @@ SStrip.DetectorVolume   Wafer
 SStrip.StructuralPitch 0.0 0.0 1.5
 //Do not indlude this part
 //SStrip.StructuralOffset 0.2 0.2 0.0
-SStrip.Offset          0.0  0.0
+SStrip.Offset          0.0  0.0 0.0
 
 //Total # of strips given by width of plane/strip pitch. Assume 0.250mm strip pitch
 SStrip.VoxelNumber 380 380 1


### PR DESCRIPTION
Changing the pixel detector to a Voxel3D detector & updating resolution/threshold (from Carolyn):

> Okay, so we’re going to go with 250 um pixels, with a noise threshold of 5 keV, a trigger threshold of 25 keV, and an energy resolution of 2% FWHM at 662 keV = 5.6 keV sigma. I think we should have it at 5 keV at 122, so this  increases from the 4.38 keV in the file.
