### PR TITLE
Updating distance between tracker planes to 1.5 cm for AMEGO-X

### DIFF
--- a/AMEGO_Midex/AmegoBase.geo.setup
+++ b/AMEGO_Midex/AmegoBase.geo.setup
@@ -15,7 +15,7 @@ World.Mother 0
 
 # This is our Tracker
 Include SiStripDetector.geo
-Include ../Detectors/SiStripProperties.det
+Include ../Detectors/SiStripXProperties.det
 
 # This is our CsI calorimeter
 Include CalorimeterCSIDetector.geo

--- a/Detectors/SiStripXProperties.det
+++ b/Detectors/SiStripXProperties.det
@@ -3,8 +3,8 @@ MDStrip2D		SStrip
 
 SStrip.SensitiveVolume  Wafer
 SStrip.DetectorVolume   Wafer
-//Structural Pitch Z coordinate for AMEGO: 60 cm / 60 planes = 1.0 cm/plane
-SStrip.StructuralPitch 0.0 0.0 1.0
+//Structural Pitch Z coordinate for AMEGO-X: 60 cm / 40 planes = 1.5 cm/plane
+SStrip.StructuralPitch 0.0 0.0 1.5
 //Do not indlude this part
 //SStrip.StructuralOffset 0.2 0.2 0.0
 SStrip.Offset          0.0  0.0


### PR DESCRIPTION
AMEGO-X has the tracker layers spaced 1.5 cm apart, this should be reflected also in the `StructuralPitch` property for geomega.